### PR TITLE
Fix address of brightness data

### DIFF
--- a/colorlight.dart
+++ b/colorlight.dart
@@ -31,11 +31,11 @@ const brightness = 0x28;
 const brightnessPercent = 3;
 
 void initFrames() {
-  frameData0107[11] = brightnessPercent;
-  frameData0107[12] = 5;
-  frameData0107[14] = brightnessPercent;
-  frameData0107[15] = brightnessPercent;
-  frameData0107[16] = brightnessPercent;
+  frameData0107[21] = brightnessPercent;
+  frameData0107[22] = 5;
+  frameData0107[24] = brightnessPercent;
+  frameData0107[25] = brightnessPercent;
+  frameData0107[26] = brightnessPercent;
 
   frameData0aff[0] = brightness;
   frameData0aff[1] = brightness;

--- a/loadimg.dart
+++ b/loadimg.dart
@@ -44,11 +44,11 @@ int getBrightness(int brightnessPercent) {
 void initFrames(brightnessPercent) {
   int brightness = getBrightness(brightnessPercent);
 
-  frameData0107[11] = brightnessPercent;
-  frameData0107[12] = 5;
-  frameData0107[14] = brightnessPercent;
-  frameData0107[15] = brightnessPercent;
-  frameData0107[16] = brightnessPercent;
+  frameData0107[21] = brightnessPercent;
+  frameData0107[22] = 5;
+  frameData0107[24] = brightnessPercent;
+  frameData0107[25] = brightnessPercent;
+  frameData0107[26] = brightnessPercent;
 
   frameData0aff[0] = brightness;
   frameData0aff[1] = brightness;


### PR DESCRIPTION
The code examples (and the blogpost) seems to refer to wrong addresses for the brightness data sent in the `0x0107` packet.

This PR will fix that. Tested on Colorlight 5A-75B 8.2 with 128x64 Eagerled P2.5 outdoor panels