### PR TITLE
Fix support for screens with 256 or more columns

### DIFF
--- a/colorlight.dart
+++ b/colorlight.dart
@@ -44,8 +44,8 @@ void initFrames() {
   frameData5500[0] = 0;
   frameData5500[1] = 0;
   frameData5500[2] = 0;
-  frameData5500[3] = 0;
-  frameData5500[4] = columnCount;
+  frameData5500[3] = columnCount >> 8;
+  frameData5500[4] = columnCount % 0xFF;
   frameData5500[5] = 0x08;
   frameData5500[6] = 0x88;
 }

--- a/loadimg.dart
+++ b/loadimg.dart
@@ -57,8 +57,8 @@ void initFrames(brightnessPercent) {
   frameData5500[0] = 0;
   frameData5500[1] = 0;
   frameData5500[2] = 0;
-  frameData5500[3] = 0;
-  frameData5500[4] = columnCount;
+  frameData5500[3] = columnCount >> 8;
+  frameData5500[4] = columnCount % 0xFF;
   frameData5500[5] = 0x08;
   frameData5500[6] = 0x88;
 }


### PR DESCRIPTION
MSB of the packet pixel count was not set correctly. This PR fixes this.

Tested on 5A-75B and 5A-75E v8.xx receivers with Eagerled P2.5 outdoor 128x64 panels